### PR TITLE
Add missing private network for Vagrant config

### DIFF
--- a/irods-single-server/Vagrantfile
+++ b/irods-single-server/Vagrantfile
@@ -33,7 +33,7 @@ Vagrant.configure("2") do |config|
     provider.vm.provision :shell, :path => '../_common/update-ipv6-settings.sh', :args => "/tmp/irods-test.env"
     provider.vm.provision :shell, :path => '../_common/initialize-network-settings.sh', :args => "/tmp/irods-test.env"
     provider.vm.provision :shell, :path => '../_common/install-irods-provider.sh', :args => "/tmp/irods-test.env"
-
+    provider.vm.network "private_network", ip: ENV['PROVIDER_IP']
   end
 
 end


### PR DESCRIPTION
This PR simply adds a missing line to the Vagrantfile regarding the private network configuration.